### PR TITLE
Add Sevilla WordCamp

### DIFF
--- a/_conferences/sevilla-wordcamp-2019.md
+++ b/_conferences/sevilla-wordcamp-2019.md
@@ -1,0 +1,13 @@
+---
+name: "WordCamp Sevilla 2019"
+website: https://2019-developers.sevilla.wordcamp.org/
+twitter: https://twitter.com/WCSevilla
+location: Sevilla, Spain
+
+date_start: 2019-10-04
+date_end:   2019-10-06
+
+cfp_start: 
+cfp_end:   
+cfp_site: 
+---


### PR DESCRIPTION
This commit adds Sevilla WordCamp 2019, there isn't CFP yet, but there is a call for sponsors. Should we add the CFS instead of?