### PR TITLE
Add JSDayES 2020

### DIFF
--- a/_conferences/jsdayes-2020.md
+++ b/_conferences/jsdayes-2020.md
@@ -1,0 +1,9 @@
+---
+name:     "JSDayES 2020"
+website:  http://2019.jsday.es/
+twitter:  https://twitter.com/jsdayes
+location: Madrid, Spain
+
+date_start: 2020-05-09
+date_end:   2020-05-09
+---


### PR DESCRIPTION
This pull request adds JSDayES 2020.

There will no be 2019 edition. (The file has a link to the 2019 website when we inform about that).

