### PR TITLE
Agrupación de eventos por año y mes, entre otros

### DIFF
--- a/_includes/general_data.html
+++ b/_includes/general_data.html
@@ -4,5 +4,5 @@
 {% endif %}
 <a class="post-link" href="{{ conference.website }}">{{ conference.name }}</a>
 {% if conference.location %}
-&nbsp;<small>{{ conference.location }}</small>
+&nbsp;<small>{{ conference.location | remove: ", Spain"}}</small>
 {% endif %}

--- a/_includes/general_data.html
+++ b/_includes/general_data.html
@@ -1,4 +1,4 @@
-{{ conference.date_start | date: "%Y-%m-%d" }}&nbsp;
+{{ conference.date_start | date: "%d" }}&nbsp;
 {% if conference.twitter %}
 <a href="{{ conference.twitter }}"><img src="img/icn_twitter.png" alt="twitter icon" width="24px"/></a>
 {% endif %}

--- a/_includes/live_data.html
+++ b/_includes/live_data.html
@@ -1,3 +1,5 @@
+{% assign date_start = conference.date_start | date: "%s" %}
+{% assign date_end = conference.date_end | date: "%s" %}
 {% if today >= date_start and today <= date_end %}
 <span class="label label-danger">Happening Now</span>
 {% endif %}

--- a/_includes/main_list.html
+++ b/_includes/main_list.html
@@ -1,0 +1,19 @@
+{% assign conferences_grouped_by_year = sorted_conferences | group_by_exp:"conference", "conference.date_start | date: '%Y'" %}
+{% for conferences_by_year in conferences_grouped_by_year %}
+  <h2>{{ conferences_by_year.name }}</h2>
+  {% assign conferences_grouped_by_month = conferences_by_year.items | group_by_exp:"conference", "conference.date_start | date: '%m'" %}
+  {% for conferences_by_month in conferences_grouped_by_month %}
+    <h3>{{ conferences_by_month.items.first.date_start | date: '%B' }}</h3>
+    <ul class="conference-list list-unstyled">
+    {% for conference in conferences_by_month.items %}  
+      <li>
+        {% include general_data.html %}
+        {% if include.type_of_events == 'upcoming' %}
+        {%   include cfp_data.html %}
+        {%   include live_data.html %}
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endfor %}
+{% endfor %}

--- a/index.html
+++ b/index.html
@@ -4,17 +4,23 @@ title: Upcoming
 ---
 
 <ul class="conference-list list-unstyled">
-{% assign sorted_conferences = site.conferences | sort: 'date_start' %}
+
 {% assign today = site.time | date: "%s" %}
+
+{% assign upcoming_conferences = "" | split: "" %}
+{% for conference in site.conferences %}
+{%   assign date_end = conference.date_end | date: "%s" %}
+{%   if today <= date_end %}
+{%     assign upcoming_conferences = upcoming_conferences | push: conference %}
+{%   endif %}
+{% endfor %}
+
+{% assign sorted_conferences = upcoming_conferences | sort: 'date_start' %}
 {% for conference in sorted_conferences %}
-  {% assign date_start = conference.date_start | date: "%s" %}
-  {% assign date_end = conference.date_end | date: "%s" %}
-  {% if today <= date_end %}
   <li>
     {% include general_data.html %}
     {% include cfp_data.html %}
     {% include live_data.html %}
   </li>
-  {% endif %}
 {% endfor %}
 </ul>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@ layout: default
 title: Upcoming
 ---
 
-<ul class="conference-list list-unstyled">
 
 {% assign today = site.time | date: "%s" %}
 
@@ -16,11 +15,20 @@ title: Upcoming
 {% endfor %}
 
 {% assign sorted_conferences = upcoming_conferences | sort: 'date_start' %}
-{% for conference in sorted_conferences %}
-  <li>
-    {% include general_data.html %}
-    {% include cfp_data.html %}
-    {% include live_data.html %}
-  </li>
+{% assign conferences_grouped_by_year = sorted_conferences | group_by_exp:"conference", "conference.date_start | date: '%Y'" %}
+{% for conferences_by_year in conferences_grouped_by_year %}
+  <h2>{{ conferences_by_year.name }}</h2>
+  {% assign conferences_grouped_by_month = conferences_by_year.items | group_by_exp:"conference", "conference.date_start | date: '%m'" %}
+  {% for conferences_by_month in conferences_grouped_by_month %}
+    <h3>{{ conferences_by_month.items.first.date_start | date: '%B' }}</h3>
+    <ul class="conference-list list-unstyled">
+    {% for conference in conferences_by_month.items %}  
+      <li>
+        {% include general_data.html %}
+        {% include cfp_data.html %}
+        {% include live_data.html %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endfor %}
 {% endfor %}
-</ul>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ title: Upcoming
 {% for conference in sorted_conferences %}
   {% assign date_start = conference.date_start | date: "%s" %}
   {% assign date_end = conference.date_end | date: "%s" %}
-  {% if today < date_end %}
+  {% if today <= date_end %}
   <li>
     {% include general_data.html %}
     {% include cfp_data.html %}

--- a/index.html
+++ b/index.html
@@ -15,20 +15,4 @@ title: Upcoming
 {% endfor %}
 
 {% assign sorted_conferences = upcoming_conferences | sort: 'date_start' %}
-{% assign conferences_grouped_by_year = sorted_conferences | group_by_exp:"conference", "conference.date_start | date: '%Y'" %}
-{% for conferences_by_year in conferences_grouped_by_year %}
-  <h2>{{ conferences_by_year.name }}</h2>
-  {% assign conferences_grouped_by_month = conferences_by_year.items | group_by_exp:"conference", "conference.date_start | date: '%m'" %}
-  {% for conferences_by_month in conferences_grouped_by_month %}
-    <h3>{{ conferences_by_month.items.first.date_start | date: '%B' }}</h3>
-    <ul class="conference-list list-unstyled">
-    {% for conference in conferences_by_month.items %}  
-      <li>
-        {% include general_data.html %}
-        {% include cfp_data.html %}
-        {% include live_data.html %}
-      </li>
-    {% endfor %}
-    </ul>
-  {% endfor %}
-{% endfor %}
+{% include main_list.html type_of_events='upcoming' %}

--- a/past.html
+++ b/past.html
@@ -4,14 +4,21 @@ title: Past
 ---
 
 <ul class="conference-list list-unstyled">
-{% assign sorted_conferences = (site.conferences | sort: 'date_start' | reverse) %}
-{% assign today = (site.time | date: "%s" ) %}
+
+{% assign today = site.time | date: "%s" %}
+
+{% assign past_conferences = "" | split: "" %}
+{% for conference in site.conferences %}
+{%   assign date_end = conference.date_end | date: "%s" %}
+{%   if today > date_end %}
+{%     assign past_conferences = past_conferences | push: conference %}
+{%   endif %}
+{% endfor %}
+
+{% assign sorted_conferences = past_conferences | sort: 'date_start' | reverse %}
 {% for conference in sorted_conferences %}
-  {% assign date_end = (conference.date_end | date: "%s") %}
-  {% if today > date_end %}
   <li>
     {% include general_data.html %}
   </li>
-  {% endif %}
 {% endfor %}
 </ul>

--- a/past.html
+++ b/past.html
@@ -16,18 +16,4 @@ title: Past
 {% endfor %}
 
 {% assign sorted_conferences = past_conferences | sort: 'date_start' | reverse %}
-{% assign conferences_grouped_by_year = sorted_conferences | group_by_exp:"conference", "conference.date_start | date: '%Y'" %}
-{% for conferences_by_year in conferences_grouped_by_year %}
-  <h2>{{ conferences_by_year.name }}</h2>
-  {% assign conferences_grouped_by_month = conferences_by_year.items | group_by_exp:"conference", "conference.date_start | date: '%m'" %}
-  {% for conferences_by_month in conferences_grouped_by_month %}
-    <h3>{{ conferences_by_month.items.first.date_start | date: '%B' }}</h3>
-    <ul class="conference-list list-unstyled">
-    {% for conference in conferences_by_month.items %}  
-      <li>
-        {% include general_data.html %}
-      </li>
-    {% endfor %}
-    </ul>
-  {% endfor %}
-{% endfor %}
+{% include main_list.html type_of_events='past' %}

--- a/past.html
+++ b/past.html
@@ -8,7 +8,7 @@ title: Past
 {% assign today = (site.time | date: "%s" ) %}
 {% for conference in sorted_conferences %}
   {% assign date_end = (conference.date_end | date: "%s") %}
-  {% if today >= date_end %}
+  {% if today > date_end %}
   <li>
     {% include general_data.html %}
   </li>

--- a/past.html
+++ b/past.html
@@ -16,9 +16,18 @@ title: Past
 {% endfor %}
 
 {% assign sorted_conferences = past_conferences | sort: 'date_start' | reverse %}
-{% for conference in sorted_conferences %}
-  <li>
-    {% include general_data.html %}
-  </li>
+{% assign conferences_grouped_by_year = sorted_conferences | group_by_exp:"conference", "conference.date_start | date: '%Y'" %}
+{% for conferences_by_year in conferences_grouped_by_year %}
+  <h2>{{ conferences_by_year.name }}</h2>
+  {% assign conferences_grouped_by_month = conferences_by_year.items | group_by_exp:"conference", "conference.date_start | date: '%m'" %}
+  {% for conferences_by_month in conferences_grouped_by_month %}
+    <h3>{{ conferences_by_month.items.first.date_start | date: '%B' }}</h3>
+    <ul class="conference-list list-unstyled">
+    {% for conference in conferences_by_month.items %}  
+      <li>
+        {% include general_data.html %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endfor %}
 {% endfor %}
-</ul>


### PR DESCRIPTION
@npatarino , por no marearte con mucha PR, he incluido 5 pequeños commits, pero dime si prefieres que haga diferentes PRs:

# Paso 1. Corrección

**Problema**. El evento JS Camp (hoy y mañana) aparece como "happening now", pero mañana no aparecería tal y como está la comparación actual. 

**Solución**. Corrección de las comparaciones con la fecha final para ambos listados: _upcoming_ and _past_.

# Paso 2. Refactor

En lugar de ordenar los eventos y después filtrarlos en el bucle _for_, se filtra y después se ordena. Esto lo he hecho para facilitar el paso 3. 

Por cierto, el filtrado quedaría más elegante con _where_exp_:
```
 {% assign upcoming_conferences = site.conferences | where_exp:"conference", "conference.date_end > site.time" %}
```
pero no se puede hacer así porque las fechas de los ficheros se consideran como objetos _Date_ y no hay manera (o no la he encontrado) de hacer una conversión a objeto _Time_ antes de la comparación en _where_exp_.

Y la forma de crear un array vacío con Liquid es un poco rara, pero no ofrecen otra opción en la documentación:

> You cannot initialize arrays using only Liquid. You can, however, use the split filter to break a string into an array of substrings.

# Paso 3. Agrupación por año y mes.

El resultado queda así:

![Screenshot from 2019-07-18 16-55-06](https://user-images.githubusercontent.com/22792183/61468718-3021b680-a97e-11e9-8d87-9255e4c812c6.png)

# Paso 4. Refactor

Extracción de la lógica de la lista principal.

# Paso 5. Mejora del listado

Eliminación de ", Spain" a la hora de mostrar la localización en los listados.

Lo dicho, si crees que es mejor en PRs diferentes, dime y las voy haciendo poco a poco.