### PR TITLE
Create aos-2023.md

### DIFF
--- a/_conferences/aos-2023.md
+++ b/_conferences/aos-2023.md
@@ -1,0 +1,9 @@
+---
+name: "Agile Open Spain 2023"
+website: https://agile-spain.org/aos/
+twitter: https://twitter.com/agileopenspain
+location: Jaca, Huesca, Spain
+
+date_start: 2023-06-30
+date_end:   2023-07-02
+---


### PR DESCRIPTION
Agile Open Spain 2023. Todavía no hay landing del evento, la web lleva a la página de Agile Spain con información genérica del evento. Se ha anunciado oficialmente la fecha durante la Conferencia Agile Spain 2022, y ya está publicada la fecha en twitter