### PR TITLE
Create devBcn-2023.md

### DIFF
--- a/_conferences/devBcn-2023.md
+++ b/_conferences/devBcn-2023.md
@@ -1,0 +1,12 @@
+---
+name: "DevBcn 2023"
+website: https://jonathanvila.wixsite.com/devbcn
+twitter: https://twitter.com/dev_bcn
+location: Barcelona, Spain
+
+date_start: 2023-07-03
+date_end:   2023-07-05
+
+cfp_end:   2023-01-01
+cfp_site: https://docs.google.com/forms/d/e/1FAIpQLSfpOwaA8FqIaIkd7_A61hJs74NiYPnMD-u7_zoMkBBEsFNlcg/viewform
+---


### PR DESCRIPTION
Creación de la conferencia DevBcn 2023, The Developers Conference. Abierto el call4papers